### PR TITLE
Erro ao abrir operação binária de 5M nos segundos finais ao inicio da vela

### DIFF
--- a/src/IqOptionApiDotNet/Wss/IqOptionWebSocketClient.BinaryOptions.cs
+++ b/src/IqOptionApiDotNet/Wss/IqOptionWebSocketClient.BinaryOptions.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Threading.Tasks;
 using IqOptionApiDotNet.Models;
 using IqOptionApiDotNet.Models.BinaryOptions;
 using IqOptionApiDotNet.Ws.Request;
+using System;
+using System.Threading.Tasks;
 
 namespace IqOptionApiDotNet.Ws
 {
@@ -33,7 +33,7 @@ namespace IqOptionApiDotNet.Ws
 
             // incasse of non-binary options
             var optionType = OptionType.Turbo;
-            if (expiration.Subtract(ServerTime).Minutes >= 5)
+            if (expiration.Subtract(ServerTime).Minutes > 5)
                 optionType = OptionType.Binary;
 
             return SendMessageAsync(


### PR DESCRIPTION
**Fato:** Ao tentar efetuar uma operação binaria nos segundos HH:mm:30 à HH:mm:59 com expiração em 5M, ocorre um erro na solicitação indicando: "O tempo para comprar essa opção já terminou, tente novamente".

**Causa:** No método `IqOptionWebSocketClient.BuyAsync` para se considerar uma tipo de operação _turbo_ deve se considerar entre 1M a 5M. Atualmente o mesmo está considerando entre 1M a 4M pois a partir de 5M está enviando tipo de operação binária causando erro ao enviar nos segundos anterior ao minuto inicial.

**Exemplo atual:**
![](https://i.ibb.co/MZ9ST4V/erro.png)

**Corrigido:**
![](https://i.ibb.co/GHcJH2D/sucesso.png)

**Solução:** Foi alterado para considerar a partir de 5 minutos: `expiration.Subtract(ServerTime).Minutes > 5` e com isto resolveu o problema de operação nos segundos finais antecedente.