### PR TITLE
Update IqOptionWebSocketClient.cs

### DIFF
--- a/src/IqOptionApiDotNet/Wss/IqOptionWebSocketClient.cs
+++ b/src/IqOptionApiDotNet/Wss/IqOptionWebSocketClient.cs
@@ -68,7 +68,7 @@ using IqOptionApiDotNet.Ws.Request;
             IObservable<TResult> observableResult)
         {
             var tcs = new TaskCompletionSource<TResult>();
-            var token = new CancellationTokenSource(5000).Token;
+            var token = new CancellationTokenSource(60000).Token;
 
             try
             {
@@ -79,7 +79,7 @@ using IqOptionApiDotNet.Ws.Request;
                     {
                         _logger.LogWarning(string.Format(
                             "Wait result for type '{0}', took long times {1} seconds. The result will send back with default {0}\n{2}",
-                            typeof(TResult), 5000, messageCreator));
+                            typeof(TResult), 60000, messageCreator));
                     }
                 });
                 


### PR DESCRIPTION
In many cases, the IQ servers take a long time to send the response, this causes time and error. This time has been increased so that there are no errors and the request can be processed successfully.
-
Em muitos casos, os servidores IQ demoram muito para enviar a resposta, isso causa tempo e erro. Este tempo foi aumentado para que não haja erros e a solicitação possa ser processada com sucesso.
-
En muchos casos, los servidores de IQ tardan mucho en enviar la respuesta, por lo que hay un retraso en el tiempo de error. Este tiempo se ha incrementado para que no haya ningún error y pueda procesar la solicitud con éxito.